### PR TITLE
Request WebSocket capabilities for terminal RPC

### DIFF
--- a/packages/terminal-worker/src/parts/IpcParentWithWebSocket/IpcParentWithWebSocket.ts
+++ b/packages/terminal-worker/src/parts/IpcParentWithWebSocket/IpcParentWithWebSocket.ts
@@ -1,13 +1,32 @@
-import { WebSocketRpcParent2 } from '@lvce-editor/rpc'
+import { WebSocketRpcParent, WebSocketRpcParent2 } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as Assert from '../Assert/Assert.ts'
 import * as CommandMapRef from '../CommandMapRef/CommandMapRef.ts'
 
 export const createWebSocketRpc = async ({ type }: { type: string }) => {
   Assert.string(type)
-  const rpc = WebSocketRpcParent2.create({
+  try {
+    const { protocols, url } = (await RendererWorker.invoke('WebSocketCapability.create', type)) as {
+      readonly protocols: string[]
+      readonly url: string
+    }
+    return WebSocketRpcParent.create({
+      commandMap: CommandMapRef.commandMapRef,
+      webSocket: new WebSocket(url, protocols),
+    })
+  } catch (error) {
+    if (
+      !(
+        error instanceof Error &&
+        (error.message.includes('WebSocketCapability.create') || error.message.includes('module WebSocketCapability not found')) &&
+        /command not found|not found/i.test(error.message)
+      )
+    ) {
+      throw error
+    }
+  }
+  return WebSocketRpcParent2.create({
     commandMap: CommandMapRef.commandMapRef,
-
     type,
   })
-  return rpc
 }


### PR DESCRIPTION
Requests a renderer-issued one-use capability before connecting to the terminal process, with a command-missing fallback for older editors.